### PR TITLE
Better this way ;)

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -2,24 +2,13 @@
 
 THIS_SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 DRIVE_API_LIB_PATH="${THIS_SCRIPTDIR}/libs/drive_api"
-cd "${DRIVE_API_LIB_PATH}"
 
 echo "Installing Google Drive python Library..."
-python setup.py install --user
+python "${DRIVE_API_LIB_PATH}/setup.py" install --user
 echo "Drive Library installed"
 
-cd "${THIS_SCRIPTDIR}"
 echo "Running script..."
-
-# export variables for python script
-export BITRISEIO_DRIVE_SECRET_URL
-export GOOGLE_DRIVE_FOLDER_KEY
-export BITRISE_IPA_PATH
-export BITRISE_DSYM_PATH
-export APP_VERSION_NUMBER
-export APP_BUILD_NUMBER
-export uploadBuildFiles
 
 FILES=(${file1} ${file2} ${file3})
 
-python Upload_Drive.py ${FILES[*]}
+python "${THIS_SCRIPTDIR}/Upload_Drive.py" ${FILES[*]}


### PR DESCRIPTION
* Why not to `cd` : relative paths are relative to the working directory. If you `cd` into the script's dir then `./my/file` will be relative to the script's dir, and not to the source code
* `export` is not necessary : the "inputs" in `step.yml` will be available as environment variables when you run the step with the Bitrise CLI

You should add a `bitrise.yml` to your step so that you can run it directly with Bitrise CLI, just like you can see it in the [Step Template](https://github.com/bitrise-steplib/step-template). You can find more info about how you can test the step with Bitrise CLI, and about how you can share it into the StepLib once you're happy with it in the https://github.com/bitrise-steplib/step-template repo ;)